### PR TITLE
The callback argument of analytics.plugins.disable should be optional

### DIFF
--- a/packages/analytics-core/src/index.js
+++ b/packages/analytics-core/src/index.js
@@ -199,7 +199,7 @@ function analytics(config = {}) {
      * Disable analytics plugin
      * @typedef {Function} DisablePlugin
      * @param  {String|Array} name - name of integration(s) to disable
-     * @param  {Function} callback - callback after disable runs
+     * @param  {Function} [callback] - callback after disable runs
      * @example
      *
      * analytics.plugins.disable('google')


### PR DESCRIPTION
Looking at the examples in the README, you can disable plugins like so:

```
// Disable a plugin by namespace
analytics.plugins.disable('google-analytics')
```

Using TypeScript, it picks up the callback parameter as required. This PR changes the JSDoc to reflect that the callback is optional.